### PR TITLE
 Add fully automatic authentication

### DIFF
--- a/tdameritrade/auth/__init__.py
+++ b/tdameritrade/auth/__init__.py
@@ -35,9 +35,28 @@ def authentication(client_id, redirect_uri):
 
     driver.get(url)
 
-    input('after giving access, hit enter to continue')
+    # Setting TDAUSER and TDAPASS enviroment variables enables
+    # fully automated oauth2 authentication 
+    if 'TDAUSER' in os.environ and 'TDAPASS' in os.environ:
+        ubox = driver.find_element_by_id('username')
+        pbox = driver.find_element_by_id('password')
+        ubox.send_keys(os.environ['TDAUSER'])
+        pbox.send_keys(os.environ['TDAPASS'])
+        driver.find_element_by_id('accept').click()
 
-    code = up.unquote(driver.current_url.split('code=')[1])
+        driver.find_element_by_id('accept').click()
+        while 1:
+            try:
+                code = up.unquote(driver.current_url.split('code=')[1])
+                if code != '':
+                    break
+                else:
+                    time.sleep(2)
+            except:
+                pass        
+    else:
+        input('after giving access, hit enter to continue')
+        code = up.unquote(driver.current_url.split('code=')[1])
 
     driver.close()
 

--- a/tdameritrade/auth/__init__.py
+++ b/tdameritrade/auth/__init__.py
@@ -35,7 +35,7 @@ def authentication(client_id, redirect_uri):
 
     driver.get(url)
 
-    # Setting TDAUSER and TDAPASS enviroment variables enables
+    # Setting TDAUSER and TDAPASS environment variables enables
     # fully automated oauth2 authentication 
     if 'TDAUSER' in os.environ and 'TDAPASS' in os.environ:
         ubox = driver.find_element_by_id('username')


### PR DESCRIPTION
This PR implements a fully automated path to obtain access and refresh tokens.  To enable, simply set TDAUSER and TDAPASS environment variables.  If they are left unset, the previous function of pausing for the user to authenticate by hand is preserved.

