### PR TITLE
client_id = consumer_key confusion

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -34,7 +34,7 @@ Set the name and id to something reasonably unique, and the redirect to ``http:/
 
 Step 5
 -------
-run ``tdameritrade.auth.authentication`` from a python prompt, with the ``client_id`` and ``redirect_uri`` from step 4.
+run ``tdameritrade.auth.authentication`` from a python prompt, with ``client_id=consumer_key`` and ``redirect_uri`` from step 4.
 
 Step 6
 -------


### PR DESCRIPTION
clear up some ambiguity. client id is the string called consumer key in the app web dashboard

also using reference https://developer.tdameritrade.com/content/simple-auth-local-apps
> https://auth.tdameritrade.com/auth?response_type=code&redirect_uri={URLENCODED REDIRECT URI}&client_id={URLENCODED Consumer Key}%40AMER.OAUTHAP 

![tdamertrade_app](https://user-images.githubusercontent.com/680742/70584732-09178b80-1b90-11ea-9004-55a60432396e.png)
