### PR TITLE
Add extra query parameters to options and history endpoints

### DIFF
--- a/tdameritrade/client.py
+++ b/tdameritrade/client.py
@@ -71,18 +71,19 @@ class TDClient(object):
     def instrumentDF(self, cusip):
         return pd.DataFrame(self.instrument(cusip))
 
-    def quote(self, symbol):
+    def quote(self, symbols):
         return requests.get(QUOTES,
                             headers=self._headers(),
-                            params={'symbol': symbol.upper()}).json()
+                            params={'symbol': symbols.upper()}).json()
 
     def quoteDF(self, symbol):
         x = self.quote(symbol)
         return pd.DataFrame(x).T.reset_index(drop=True)
 
-    def history(self, symbol):
+    def history(self, symbol, **kwargs):
         return requests.get(HISTORY % symbol,
-                            headers=self._headers()).json()
+                            headers=self._headers(),
+                            params=kwargs).json()
 
     def historyDF(self, symbol):
         x = self.history(symbol)
@@ -90,10 +91,10 @@ class TDClient(object):
         df['datetime'] = pd.to_datetime(df['datetime'], unit='ms')
         return df
 
-    def options(self, symbol):
+    def options(self, symbol, **kwargs):
         return requests.get(OPTIONCHAIN,
                             headers=self._headers(),
-                            params={'symbol': symbol.upper()}).json()
+                            params={'symbol': symbol.upper(), **kwargs}).json()
 
     def optionsDF(self, symbol):
         ret = []


### PR DESCRIPTION
Adds the ability to enter extra query parameters into the `options` and `history` client endpoints.