### PR TITLE
Automatically refresh token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ keys.sh
 
 .autoversion
 docs/api
+
+# IDE
+.ctrlpignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.22.0
+selenium==3.141.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+mock==3.0.5
+pandas==0.25.3
 requests==2.22.0
 selenium==3.141.0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+pushd $DIR/..
+python3 -m unittest discover tdameritrade/tests
+popd

--- a/tdameritrade/auth/__init__.py
+++ b/tdameritrade/auth/__init__.py
@@ -1,11 +1,12 @@
 import os
 import os.path
 import sys
-import requests
 import time
-from selenium import webdriver
-from shutil import which
 import urllib.parse as up
+from shutil import which
+
+import requests
+from selenium import webdriver
 
 
 def authentication(client_id, redirect_uri, tdauser=None, tdapass=None):

--- a/tdameritrade/auth/__init__.py
+++ b/tdameritrade/auth/__init__.py
@@ -78,7 +78,7 @@ def authentication(client_id, redirect_uri, tdauser=None, tdapass=None):
     return resp.json()
 
 
-def refresh_token(refresh_token, client_id):
+def access_token(refresh_token, client_id):
     resp = requests.post('https://api.tdameritrade.com/v1/oauth2/token',
                          headers={'Content-Type': 'application/x-www-form-urlencoded'},
                          data={'grant_type': 'refresh_token',

--- a/tdameritrade/client.py
+++ b/tdameritrade/client.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import pandas as pd
 import requests
@@ -16,16 +17,21 @@ class TDClient(object):
         self._clientId = clientId
         self._refreshToken = refreshToken
         self._accessToken = accessToken or os.environ['ACCESS_TOKEN']
-        self._refreshTokenAgeSecs = 0
+        self._accessTokenCreatedAt = time.time()
         self.accountIds = accountIds or []
 
     def _headers(self):
         return {'Authorization': 'Bearer ' + self._accessToken}
 
     def _refresh_token_if_expired(self):
-        if self._refreshTokenAgeSecs >= ACCESS_TOKEN_EXPIRATION_TIME_SECS:
+        if self._accessToken is None or \
+                self._access_token_age_secs() >= ACCESS_TOKEN_EXPIRATION_TIME_SECS:
             self._accessToken = auth.refresh_token(self._refreshToken,
                                                    self._clientId)
+
+    def _access_token_age_secs(self):
+        return time.time() - self._accessTokenCreatedAt
+
 
     def accounts(self, positions=False, orders=False):
         ret = {}

--- a/tdameritrade/tests/test_client.py
+++ b/tdameritrade/tests/test_client.py
@@ -1,8 +1,10 @@
 # for Coverage
-from mock import patch, MagicMock
+import unittest
+
+from mock import MagicMock, patch
 
 
-class TestExtension:
+class TestClient(unittest.TestCase):
     def setup(self):
         pass
         # setup() before each test method
@@ -23,20 +25,20 @@ class TestExtension:
 
     def test_init(self):
         from tdameritrade import TDClient
-        tdc = TDClient('test')
-        tdc._headers()
+        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
+        self.assertEqual(tdc._accessToken, 'accesstoken')
 
     def test_accounts(self):
         from tdameritrade import TDClient
 
-        tdc = TDClient('test', [1, 2])
+        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
             m.return_value.json.return_value = [MagicMock()]
             tdc.accounts()
 
-        tdc = TDClient('test', [1, 2])
+        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -50,7 +52,7 @@ class TestExtension:
     def test_search(self):
         from tdameritrade import TDClient
 
-        tdc = TDClient('test', [1, 2])
+        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -61,7 +63,7 @@ class TestExtension:
     def test_instrument(self):
         from tdameritrade import TDClient
 
-        tdc = TDClient('test', [1, 2])
+        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -72,7 +74,7 @@ class TestExtension:
     def test_quote(self):
         from tdameritrade import TDClient
 
-        tdc = TDClient('test', [1, 2])
+        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -83,7 +85,7 @@ class TestExtension:
     def test_history(self):
         from tdameritrade import TDClient
 
-        tdc = TDClient('test', [1, 2])
+        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -94,7 +96,7 @@ class TestExtension:
     def test_movers(self):
         from tdameritrade import TDClient
 
-        tdc = TDClient('test', [1, 2])
+        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200

--- a/tdameritrade/tests/test_client.py
+++ b/tdameritrade/tests/test_client.py
@@ -26,15 +26,15 @@ class TestClient(unittest.TestCase):
     def test_init(self):
         from tdameritrade import TDClient
         tdc = TDClient(clientId=123, refreshToken='reftoken',
-                       accessToken='accesstoken', accountIds=[1, 2])
-        self.assertEqual(tdc._accessToken['token'], 'accesstoken')
+                       accountIds=[1, 2])
+        self.assertEqual(tdc._refreshToken['token'], 'reftoken')
 
-    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    @patch('tdameritrade.TDClient._updateAccessTokenIfExpired')
     def test_accounts(self, mock_rtie):
         from tdameritrade import TDClient
 
         tdc = TDClient(clientId=123, refreshToken='reftoken',
-                       accessToken='accesstoken', accountIds=[1, 2])
+                       accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -42,7 +42,7 @@ class TestClient(unittest.TestCase):
             tdc.accounts()
 
         tdc = TDClient(clientId=123, refreshToken='reftoken',
-                       accessToken='accesstoken', accountIds=[1, 2])
+                       accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -53,12 +53,12 @@ class TestClient(unittest.TestCase):
             m.return_value.json.return_value = [{'test': 1, 'test2': 2}]
             tdc.accountsDF()
 
-    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    @patch('tdameritrade.TDClient._updateAccessTokenIfExpired')
     def test_search(self, mock_rtie):
         from tdameritrade import TDClient
 
         tdc = TDClient(clientId=123, refreshToken='reftoken',
-                       accessToken='accesstoken', accountIds=[1, 2])
+                       accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -66,12 +66,12 @@ class TestClient(unittest.TestCase):
             tdc.search('aapl')
             tdc.searchDF('aapl')
 
-    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    @patch('tdameritrade.TDClient._updateAccessTokenIfExpired')
     def test_instrument(self, mock_rtie):
         from tdameritrade import TDClient
 
         tdc = TDClient(clientId=123, refreshToken='reftoken',
-                       accessToken='accesstoken', accountIds=[1, 2])
+                       accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -79,12 +79,12 @@ class TestClient(unittest.TestCase):
             tdc.instrument('aapl')
             tdc.instrumentDF('aapl')
 
-    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    @patch('tdameritrade.TDClient._updateAccessTokenIfExpired')
     def test_quote(self, mock_rtie):
         from tdameritrade import TDClient
 
         tdc = TDClient(clientId=123, refreshToken='reftoken',
-                       accessToken='accesstoken', accountIds=[1, 2])
+                       accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -92,12 +92,12 @@ class TestClient(unittest.TestCase):
             tdc.quote('aapl')
             tdc.quoteDF('aapl')
 
-    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    @patch('tdameritrade.TDClient._updateAccessTokenIfExpired')
     def test_history(self, mock_rtie):
         from tdameritrade import TDClient
 
         tdc = TDClient(clientId=123, refreshToken='reftoken',
-                       accessToken='accesstoken', accountIds=[1, 2])
+                       accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -109,7 +109,7 @@ class TestClient(unittest.TestCase):
         from tdameritrade import TDClient
 
         tdc = TDClient(clientId=123, refreshToken='reftoken',
-                       accessToken='accesstoken', accountIds=[1, 2])
+                       accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200

--- a/tdameritrade/tests/test_client.py
+++ b/tdameritrade/tests/test_client.py
@@ -25,20 +25,24 @@ class TestClient(unittest.TestCase):
 
     def test_init(self):
         from tdameritrade import TDClient
-        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
-        self.assertEqual(tdc._accessToken, 'accesstoken')
+        tdc = TDClient(clientId=123, refreshToken='reftoken',
+                       accessToken='accesstoken', accountIds=[1, 2])
+        self.assertEqual(tdc._accessToken['token'], 'accesstoken')
 
-    def test_accounts(self):
+    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    def test_accounts(self, mock_rtie):
         from tdameritrade import TDClient
 
-        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
+        tdc = TDClient(clientId=123, refreshToken='reftoken',
+                       accessToken='accesstoken', accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
             m.return_value.json.return_value = [MagicMock()]
             tdc.accounts()
 
-        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
+        tdc = TDClient(clientId=123, refreshToken='reftoken',
+                       accessToken='accesstoken', accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -49,10 +53,12 @@ class TestClient(unittest.TestCase):
             m.return_value.json.return_value = [{'test': 1, 'test2': 2}]
             tdc.accountsDF()
 
-    def test_search(self):
+    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    def test_search(self, mock_rtie):
         from tdameritrade import TDClient
 
-        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
+        tdc = TDClient(clientId=123, refreshToken='reftoken',
+                       accessToken='accesstoken', accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -60,10 +66,12 @@ class TestClient(unittest.TestCase):
             tdc.search('aapl')
             tdc.searchDF('aapl')
 
-    def test_instrument(self):
+    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    def test_instrument(self, mock_rtie):
         from tdameritrade import TDClient
 
-        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
+        tdc = TDClient(clientId=123, refreshToken='reftoken',
+                       accessToken='accesstoken', accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -71,10 +79,12 @@ class TestClient(unittest.TestCase):
             tdc.instrument('aapl')
             tdc.instrumentDF('aapl')
 
-    def test_quote(self):
+    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    def test_quote(self, mock_rtie):
         from tdameritrade import TDClient
 
-        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
+        tdc = TDClient(clientId=123, refreshToken='reftoken',
+                       accessToken='accesstoken', accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -82,10 +92,12 @@ class TestClient(unittest.TestCase):
             tdc.quote('aapl')
             tdc.quoteDF('aapl')
 
-    def test_history(self):
+    @patch('tdameritrade.TDClient._refreshTokenIfExpired')
+    def test_history(self, mock_rtie):
         from tdameritrade import TDClient
 
-        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
+        tdc = TDClient(clientId=123, refreshToken='reftoken',
+                       accessToken='accesstoken', accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200
@@ -96,7 +108,8 @@ class TestClient(unittest.TestCase):
     def test_movers(self):
         from tdameritrade import TDClient
 
-        tdc = TDClient(123, 'reftoken', 'accesstoken', [1, 2])
+        tdc = TDClient(clientId=123, refreshToken='reftoken',
+                       accessToken='accesstoken', accountIds=[1, 2])
 
         with patch('requests.get') as m:
             m.return_value.status_code = 200


### PR DESCRIPTION
I added the ability for TDClient to track the access token age and refresh it in time so that the user of the API doesn't have to handle access token regeneration in his or her code. As such, I removed the accessToken argument from the TDClient constructor. The constructor uses the refresh token to request a new access token and track its age.

I also renamed `auth.referesh_token()` to `auth.access_token()`, because the function returns an access token, not a refresh token.

I am happy to work more on this library as I enhance it and clean it up for my own use. It would be good to write actual tests. The test file doesn't really contain tests.