### PR TITLE
remove json() call from orders endpoint

### DIFF
--- a/tdameritrade/client.py
+++ b/tdameritrade/client.py
@@ -120,4 +120,4 @@ class TDClient(object):
     def orders(self, account_id, order):
         return requests.post(ACCOUNTS + account_id + "/orders",
                              headers=self._headers(),
-                             json=order).json()
+                             json=order)


### PR DESCRIPTION
**Overview**

It turns out that the `/orders` endpoint will not always return a response containing JSON. In such cases the call to `.json()` after making the post request will raise an exception. I've removed the .json() call so the user of the client can decide how to handle the response object.

cc @arh 