### PR TITLE
Add start and end date params to history api

### DIFF
--- a/tdameritrade/client.py
+++ b/tdameritrade/client.py
@@ -245,6 +245,12 @@ class TDClient(object):
             params['frequency'] = frequency
             params['frequencyType'] = frequencyType
 
+        if startDate:
+            params['startDate'] = startDate
+
+        if endDate:
+            params['endDate'] = endDate
+
         return self._request(GET_PRICE_HISTORY.format(symbol=symbol), params=params).json()
 
     def historyDF(self, symbol, **kwargs):


### PR DESCRIPTION
Updated function to allow `endData` and `startDate` parameters to pass through to the request.