### PR TITLE
changed accountsDF to process each account in the accounts dictionary

### DIFF
--- a/tdameritrade/client.py
+++ b/tdameritrade/client.py
@@ -119,7 +119,11 @@ class TDClient(object):
 
     def accountsDF(self):
         '''get accounts as dataframe'''
-        return pd.io.json.json_normalize(self.accounts())
+        data = self.accounts()
+        account_dataframes = []
+        for key, value in data.items():
+            account_dataframes.append(pd.json_normalize(value))
+        return pd.concat(account_dataframes)
 
     def transactions(self, accountId=None, type=None, symbol=None, startDate=None, endDate=None):
         '''get transactions by account


### PR DESCRIPTION
closes #79 . Fixes the error from the accounts dictionary not being able to be normalized because it is a single dictionary and not a list of records. This error occurred for users with a single account (unknown if this was a error for users with multiple accounts) but the fix should work for an arbitrary number of accounts.   