### PR TITLE
Updated Web Auth flow for 2FA 

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -1,0 +1,13 @@
+# TDA Config vars
+TDA_API_KEY=<tda_api_key_here>@AMER.OAUTHAP
+TDA_CALLBACK_URI=<callback_uri_here>
+TDA_USERNAME=<tda_username_here>
+TDA_PASSWORD=<tda_password_here>
+TDA_SECURITY_QUESTIONS_1=<tda_question_list_here>
+TDA_SECURITY_QUESTIONS_2=<tda_question_list_here>
+TDA_SECURITY_QUESTIONS_3=<tda_question_list_here>
+TDA_SECURITY_QUESTIONS_4=<tda_question_list_here>
+TDA_SECURITY_QUESTION_ANSWERS_1=<tda_question_answer_list_here>
+TDA_SECURITY_QUESTION_ANSWERS_2=<tda_question_answer_list_here>
+TDA_SECURITY_QUESTION_ANSWERS_3=<tda_question_answer_list_here>
+TDA_SECURITY_QUESTION_ANSWERS_4=<tda_question_answer_list_here>

--- a/.env.default
+++ b/.env.default
@@ -1,13 +1,13 @@
 # TDA Config vars
-TDA_API_KEY=<tda_api_key_here>@AMER.OAUTHAP
+TDAMERITRADE_CLIENT_ID=<tda_api_key_here>@AMER.OAUTHAP
 TDA_CALLBACK_URI=<callback_uri_here>
 TDA_USERNAME=<tda_username_here>
 TDA_PASSWORD=<tda_password_here>
-TDA_SECURITY_QUESTIONS_1=<tda_question_list_here>
-TDA_SECURITY_QUESTIONS_2=<tda_question_list_here>
-TDA_SECURITY_QUESTIONS_3=<tda_question_list_here>
-TDA_SECURITY_QUESTIONS_4=<tda_question_list_here>
-TDA_SECURITY_QUESTION_ANSWERS_1=<tda_question_answer_list_here>
-TDA_SECURITY_QUESTION_ANSWERS_2=<tda_question_answer_list_here>
-TDA_SECURITY_QUESTION_ANSWERS_3=<tda_question_answer_list_here>
-TDA_SECURITY_QUESTION_ANSWERS_4=<tda_question_answer_list_here>
+TDA_SECURITY_QUESTION_1=<tda_question_list_here>
+TDA_SECURITY_QUESTION_2=<tda_question_list_here>
+TDA_SECURITY_QUESTION_3=<tda_question_list_here>
+TDA_SECURITY_QUESTION_4=<tda_question_list_here>
+TDA_SECURITY_QUESTION_ANSWER_1=<tda_question_answer_list_here>
+TDA_SECURITY_QUESTION_ANSWER_2=<tda_question_answer_list_here>
+TDA_SECURITY_QUESTION_ANSWER_3=<tda_question_answer_list_here>
+TDA_SECURITY_QUESTION_ANSWER_4=<tda_question_answer_list_here>

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ python_junit.xml
 # IDE
 .ctrlpignore
 
+# PyCharm idea files
+.idea/*

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -26,12 +26,21 @@ Set the name and id to something reasonably unique, and the redirect to `http://
 
 
 ### Step 5
-run `tdameritrade.auth.authentication` from a python prompt, with `client_id=consumer_key` and `redirect_uri` from step 4.
+Run `tdameritrade.auth.authentication` from a python prompt, with `client_id=consumer_key` and `redirect_uri` from step 4.
 
 ### Step 6
 Sign in and authorize your app.
 
-You can enter credentials by hand or store them in environment variables `TDAUSER` and `TDAPASS`. When stored, the first page will be filled in and advanced automaticly. 
+You can enter credentials by hand. 
+
+Or store them in environment variables in `.env`:
+
+- Copy `.env.default` to `.env` and fill out
+
+If you setup all of the env variables in `.env`, including the Security QA vars, 
+the entire web form will be filled in and complete automatically returning the OAuth token.
+( If you did this skip Step 7 and store your tokens. )
+
 
 ```eval_rst
 .. image:: ./img/auth/2.png
@@ -44,7 +53,8 @@ You can enter credentials by hand or store them in environment variables `TDAUSE
 ```
 
 ### Step 7
-Return to the prompt, if you entered the info correctly you should see your tokens printed. Write these down, i recommend keeping a `keys.sh` file setting `ACCESS_TOKEN` and `REFRESH_TOKEN` environment variables. 
+Return to the prompt, if you entered the info correctly you should see your tokens printed. 
+Write these down, i recommend keeping a `keys.sh` file setting `ACCESS_TOKEN` and `REFRESH_TOKEN` environment variables. 
 
 
 ```eval_rst

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+setuptools~=46.0.0
+requests~=2.23.0
+python-dotenv~=0.13.0
+pandas~=1.0.3
+tdameritrade~=0.1.0
+pytest~=5.4.1
+mock~=4.0.2
+selenium
+webdriver-manager

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ setuptools~=46.1.3
 requests~=2.23.0
 python-dotenv~=0.13.0
 pandas~=1.0.3
-tdameritrade~=0.1.0
 pytest~=5.4.1
 mock~=4.0.2
 selenium==3.141.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-setuptools~=46.0.0
+setuptools~=46.1.3
 requests~=2.23.0
 python-dotenv~=0.13.0
 pandas~=1.0.3
 tdameritrade~=0.1.0
 pytest~=5.4.1
 mock~=4.0.2
-selenium
-webdriver-manager
+selenium==3.141.0
+webdriver-manager~=2.4.0
+requests-oauthlib~=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ def get_version(file, name='__version__'):
         exec(f.read(), {}, version_ns)
     return version_ns[name]
 
+
 version = get_version(pjoin(here, name, '_version.py'))
 
 with open(pjoin(here, 'README.md'), encoding='utf-8') as f:
@@ -27,16 +28,18 @@ requires = [
     'pandas>=0.22.0',
     'ujson>=1.35',
     'selenium==3.141.0',
+    'requests-oauthlib>=1.3.0',
+    'webdriver-manager>=2.4.0',
 ]
 
 requires_dev = [
-    'flake8>=3.7.8',
-    'mock',
-    'pytest>=4.3.0',
-    'pytest-cov>=2.6.1',
-    'Sphinx>=1.8.4',
-    'sphinx-markdown-builder>=0.5.2',
-] + requires
+                   'flake8>=3.7.8',
+                   'mock',
+                   'pytest>=4.3.0',
+                   'pytest-cov>=2.6.1',
+                   'Sphinx>=1.8.4',
+                   'sphinx-markdown-builder>=0.5.2',
+               ] + requires
 
 setup(
     name=name,

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requires = [
     'pandas>=0.22.0',
     'ujson>=1.35',
     'selenium==3.141.0',
+    'python-dotenv>=0.13.0',
     'requests-oauthlib>=1.3.0',
     'webdriver-manager>=2.4.0',
 ]

--- a/tdameritrade/auth/__init__.py
+++ b/tdameritrade/auth/__init__.py
@@ -1,82 +1,29 @@
-import os
-import os.path
-import sys
-import time
-import urllib.parse as up
-from shutil import which
-
 import requests
 
+from tdameritrade.auth.auth_form_executioner import FormExecutioner
+from tdameritrade.auth.tda_config_provider import TDAConfigProvider, TDAConfig
+from tdameritrade.auth.web_driver_provider import WebDriverProvider
 
-def authentication(client_id, redirect_uri, tdauser=None, tdapass=None):
-    from selenium import webdriver
-    client_id = client_id + '@AMER.OAUTHAP'
-    url = 'https://auth.tdameritrade.com/auth?response_type=code&redirect_uri=' + up.quote(redirect_uri) + '&client_id=' + up.quote(client_id)
 
-    options = webdriver.ChromeOptions()
-
-    if sys.platform == 'darwin':
-        # MacOS
-        if os.path.exists("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"):
-            options.binary_location = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-        elif os.path.exists("/Applications/Chrome.app/Contents/MacOS/Google Chrome"):
-            options.binary_location = "/Applications/Chrome.app/Contents/MacOS/Google Chrome"
-    elif 'linux' in sys.platform:
-        # Linux
-        options.binary_location = which('google-chrome') or which('chrome') or which('chromium')
-
+def authentication(
+        client_id=None,
+        redirect_uri=None,
+        tdauser=None,
+        tdapass=None):
+    # handles arguments or loading config from .env
+    if client_id is None:
+        tda_config = TDAConfigProvider.get_config()
     else:
-        # Windows
-        if os.path.exists('C:/Program Files (x86)/Google/Chrome/Application/chrome.exe'):
-            options.binary_location = 'C:/Program Files (x86)/Google/Chrome/Application/chrome.exe'
-        elif os.path.exists('C:/Program Files/Google/Chrome/Application/chrome.exe'):
-            options.binary_location = 'C:/Program Files/Google/Chrome/Application/chrome.exe'
+        tda_config = TDAConfig(
+            client_id,
+            redirect_uri,
+            tdauser,
+            tdapass
+        )
 
-    chrome_driver_binary = which('chromedriver') or "/usr/local/bin/chromedriver"
-    driver = webdriver.Chrome(chrome_driver_binary, chrome_options=options)
-
-    driver.get(url)
-
-    # Set tdauser and tdapass from environemnt if TDAUSER and TDAPASS environment variables were defined
-    tdauser = tdauser or os.environ.get('TDAUSER', '')
-    tdapass = tdapass or os.environ.get('TDAPASS', '')
-
-    # Fully automated oauth2 authentication (if tdauser and tdapass were intputed into the function, or found as
-    # environment variables)
-    if tdauser and tdapass:
-        ubox = driver.find_element_by_id('username')
-        pbox = driver.find_element_by_id('password')
-        ubox.send_keys(tdauser)
-        pbox.send_keys(tdapass)
-        driver.find_element_by_id('accept').click()
-
-        driver.find_element_by_id('accept').click()
-        while True:
-            try:
-                code = up.unquote(driver.current_url.split('code=')[1])
-                if code != '':
-                    break
-                else:
-                    time.sleep(2)
-            except (TypeError, IndexError):
-                pass
-    else:
-        input('after giving access, hit enter to continue')
-        code = up.unquote(driver.current_url.split('code=')[1])
-
-    driver.close()
-
-    resp = requests.post('https://api.tdameritrade.com/v1/oauth2/token',
-                         headers={'Content-Type': 'application/x-www-form-urlencoded'},
-                         data={'grant_type': 'authorization_code',
-                               'refresh_token': '',
-                               'access_type': 'offline',
-                               'code': code,
-                               'client_id': client_id,
-                               'redirect_uri': redirect_uri})
-    if resp.status_code != 200:
-        raise Exception('Could not authenticate!')
-    return resp.json()
+    return FormExecutioner(
+        tda_config,
+        WebDriverProvider.get_web_driver()).get_token()
 
 
 def access_token(refresh_token, client_id):
@@ -86,7 +33,13 @@ def access_token(refresh_token, client_id):
                                'refresh_token': refresh_token,
                                'client_id': client_id})
     if resp.status_code != 200:
-        raise Exception('Could not authenticate!')
+
+        # Attempt to refresh token via web flow
+        token = authentication()
+        if token == "" or token is None:
+            raise Exception('Could not authenticate!')
+        else:
+            return token
     return resp.json()
 
 

--- a/tdameritrade/auth/auth_form_executioner.py
+++ b/tdameritrade/auth/auth_form_executioner.py
@@ -1,0 +1,108 @@
+import time
+
+import requests_oauthlib
+
+
+class FormExecutioner:
+    tda_auth_url = 'https://auth.tdameritrade.com/auth'
+    tda_refresh_token_url = 'https://api.tdameritrade.com/v1/oauth2/token'
+
+    def __init__(
+            self,
+            config,
+            web_driver
+    ):
+        self.tda_config = config
+        self.web_driver = web_driver
+
+    def complete_form_login(self):
+
+        # Fill in credentials on login page
+        input_username = self.web_driver.find_element_by_id("username")
+        input_username.send_keys(self.tda_config.tda_username)
+
+        input_password = self.web_driver.find_element_by_id("password")
+        input_password.send_keys(self.tda_config.tda_password)
+
+        button = self.web_driver.find_element_by_id("accept")
+        button.click()
+
+    def complete_selection_alternate_2fa(self):
+
+        # Navigate to alternate 2FA option and select "security question" option
+        button_alternates = self.web_driver.find_elements_by_class_name("alternates")[0]
+        button_alternates.click()
+
+        button_use_security_question = self.web_driver.find_elements_by_name("init_secretquestion")[0]
+        button_use_security_question.click()
+
+    def complete_form_security_question(self):
+
+        # Navigate to security question page and enter security question
+        # 1. Get security question from form
+        text_security_question_p_tag = self.web_driver.find_elements_by_css_selector("div.row.description")[0].text
+        text_security_question = text_security_question_p_tag.split("Question: ")[1]
+        idx_security_question = 0
+
+        # 2. Find index of question to grab the answer for that idx from tda_config
+        for idx, question in enumerate(self.tda_config.tda_security_questions):
+            if text_security_question.find(question) != -1:
+                idx_security_question = idx
+
+        security_question_answer = self.tda_config.tda_security_question_answers[idx_security_question]
+
+        # 3. Fill in security question answer
+        input_security_question = self.web_driver.find_element_by_id("secretquestion")
+        input_security_question.send_keys(security_question_answer)
+
+        # 4. Submit form
+        button_submit_security_question_form = self.web_driver.find_element_by_id("accept")
+        button_submit_security_question_form.click()
+
+    def complete_form_authorize(self):
+
+        # Hit allow on "TD Ameritrade Authorization" screen
+        button_submit_allow = self.web_driver.find_element_by_id("accept")
+        button_submit_allow.click()
+
+    def get_token(self, wait_time_seconds=1.5):
+
+        oauth = requests_oauthlib.OAuth2Session(
+            self.tda_config.api_key,
+            redirect_uri=self.tda_config.callback_uri)
+        authorization_url, state = oauth.authorization_url(self.tda_auth_url)
+
+        # Open the login page and wait for the redirect
+        # It will redirect once the form has been completed
+        self.web_driver.get(authorization_url)
+        callback_url = ''
+
+        while not callback_url.startswith(self.tda_config.callback_uri):
+            # 1. Go through login form
+            self.complete_form_login()
+
+            time.sleep(wait_time_seconds)
+
+            # 2. Hit alternate 2fa option to use security questions
+            self.complete_selection_alternate_2fa()
+
+            time.sleep(wait_time_seconds)
+
+            # 3. Fill in security question
+            self.complete_form_security_question()
+
+            time.sleep(wait_time_seconds)
+
+            # 4. Hit authorize and complete
+            self.complete_form_authorize()
+
+            callback_url = self.web_driver.current_url
+
+            self.web_driver.close()
+
+        return oauth.fetch_token(
+            self.tda_refresh_token_url,
+            authorization_response=callback_url,
+            access_type='offline',
+            client_id=self.tda_config.api_key,
+            include_client_id=True)

--- a/tdameritrade/auth/tda_config_provider.py
+++ b/tdameritrade/auth/tda_config_provider.py
@@ -1,0 +1,51 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class TDAConfig:
+
+    def __init__(
+            self,
+            api_key,
+            callback_uri,
+            tda_username,
+            tda_password,
+            tda_security_questions,
+            tda_security_question_answers
+    ):
+        self.api_key = api_key
+        self.callback_uri = callback_uri
+        self.tda_username = tda_username
+        self.tda_password = tda_password
+        self.tda_security_questions = tda_security_questions
+        self.tda_security_question_answers = tda_security_question_answers
+
+
+class TDAConfigProvider:
+
+    @staticmethod
+    def get_config():
+        tda_security_questions = [
+            os.getenv('TDA_SECURITY_QUESTION_1'),
+            os.getenv('TDA_SECURITY_QUESTION_2'),
+            os.getenv('TDA_SECURITY_QUESTION_3'),
+            os.getenv('TDA_SECURITY_QUESTION_4')
+        ]
+
+        tda_security_question_answers = [
+            os.getenv('TDA_SECURITY_QUESTION_ANSWER_1'),
+            os.getenv('TDA_SECURITY_QUESTION_ANSWER_2'),
+            os.getenv('TDA_SECURITY_QUESTION_ANSWER_3'),
+            os.getenv('TDA_SECURITY_QUESTION_ANSWER_4')
+        ]
+
+        return TDAConfig(
+            api_key=os.getenv('TDA_API_KEY'),
+            callback_uri=os.getenv('TDA_CALLBACK_URI'),
+            tda_username=os.getenv('TDA_USERNAME'),
+            tda_password=os.getenv('TDA_PASSWORD'),
+            tda_security_questions=tda_security_questions,
+            tda_security_question_answers=tda_security_question_answers
+        )

--- a/tdameritrade/auth/tda_config_provider.py
+++ b/tdameritrade/auth/tda_config_provider.py
@@ -42,7 +42,7 @@ class TDAConfigProvider:
         ]
 
         return TDAConfig(
-            api_key=os.getenv('TDA_API_KEY'),
+            api_key=os.getenv('TDAMERITRADE_CLIENT_ID'),
             callback_uri=os.getenv('TDA_CALLBACK_URI'),
             tda_username=os.getenv('TDA_USERNAME'),
             tda_password=os.getenv('TDA_PASSWORD'),

--- a/tdameritrade/auth/web_driver_provider.py
+++ b/tdameritrade/auth/web_driver_provider.py
@@ -1,0 +1,19 @@
+class WebDriverProvider:
+
+    @staticmethod
+    def get_web_driver(use_headless_web_driver=True):
+        from selenium import webdriver
+        from webdriver_manager.chrome import ChromeDriverManager
+
+        chrome_driver_binary_path = ChromeDriverManager().install()
+
+        chrome_options = webdriver.ChromeOptions()
+
+        if use_headless_web_driver:
+            chrome_options.add_argument('--headless')
+            chrome_options.add_argument("--no-sandbox")
+            chrome_options.add_argument('--disable-gpu')
+            chrome_options.add_argument('--disable-dev-shm-usage')
+            chrome_options.add_argument("--window-size=1920, 1200")
+
+        return webdriver.Chrome(chrome_driver_binary_path, chrome_options=chrome_options)


### PR DESCRIPTION
- Added TDA auth web form executioner with 2FA steps 
- Updated to use ChromeDriverManger to load selenium chrome driver ( easier to use than previous solution ) 
-  Updated docs/authentication.md with details for .env

Test the new auth flow:
```
from tdameritrade.auth import TDAConfigProvider, access_token

token = access_token("bad_refresh_token_to_invoke_web_auth", TDAConfigProvider.get_config().api_key)

print(token)
```