### PR TITLE
Add order examples to Jupyter Notebook

### DIFF
--- a/general.ipynb
+++ b/general.ipynb
@@ -1,14 +1,38 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# General Usage"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pprint import pprint\n",
-    "import tdameritrade as td\n",
-    "c = td.TDClient()"
+    "import tdameritrade as td"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Authentication\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client_id = \"\"\n",
+    "refresh_token = \"\""
    ]
   },
   {
@@ -17,210 +41,243 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# shows private account info\n",
-    "# pprint(c.accounts())"
+    "# Authorize TD Client\n",
+    "td_client = td.TDClient(client_id=client_id, refresh_token=refresh_token)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API Examples"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'AAPL': {'assetType': 'EQUITY',\n",
-      "          'cusip': '037833100',\n",
-      "          'description': 'Apple Inc. - Common Stock',\n",
-      "          'exchange': 'NASDAQ',\n",
-      "          'symbol': 'AAPL'}}\n"
-     ]
-    }
-   ],
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
-    "pprint(c.search('aapl'))"
+    "# shows private account info\n",
+    "# pprint(td_client.accounts())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Getting Symbol Data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": 6,
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "{'AAPL': {'52WkHigh': 229.67,\n",
-      "          '52WkLow': 150.24,\n",
-      "          'askId': 'P',\n",
-      "          'askPrice': 225.93,\n",
-      "          'askSize': 700,\n",
-      "          'assetType': 'EQUITY',\n",
-      "          'bidId': 'Q',\n",
-      "          'bidPrice': 225.82,\n",
-      "          'bidSize': 200,\n",
-      "          'bidTick': ' ',\n",
-      "          'closePrice': 225.74,\n",
-      "          'delayed': True,\n",
-      "          'description': 'Apple Inc. - Common Stock',\n",
-      "          'digits': 4,\n",
-      "          'divAmount': 2.92,\n",
-      "          'divDate': '2018-08-10 00:00:00.0',\n",
-      "          'divYield': 1.29,\n",
-      "          'exchange': 'q',\n",
-      "          'exchangeName': 'NASDAQ',\n",
-      "          'highPrice': 225.84,\n",
-      "          'lastId': 'D',\n",
-      "          'lastPrice': 225.93,\n",
-      "          'lastSize': 100,\n",
-      "          'lowPrice': 224.02,\n",
-      "          'marginable': True,\n",
-      "          'mark': 225.74,\n",
-      "          'nAV': 0.0,\n",
-      "          'netChange': 0.19,\n",
-      "          'openPrice': 224.79,\n",
-      "          'peRatio': 20.16,\n",
-      "          'quoteTimeInLong': 1538179186513,\n",
-      "          'regularMarketLastPrice': 225.74,\n",
-      "          'regularMarketLastSize': 130,\n",
-      "          'regularMarketNetChange': 0.0,\n",
-      "          'regularMarketTradeTimeInLong': 1538164803974,\n",
-      "          'securityStatus': 'Normal',\n",
-      "          'shortable': True,\n",
-      "          'symbol': 'AAPL',\n",
-      "          'totalVolume': 22929364,\n",
-      "          'tradeTimeInLong': 1538179186515,\n",
-      "          'volatility': 0.0061566425}}\n"
-     ]
+     "name": "stdout",
+     "text": "{'AAPL': {'assetType': 'EQUITY',\n          'cusip': '037833100',\n          'description': 'Apple Inc. - Common Stock',\n          'exchange': 'NASDAQ',\n          'symbol': 'AAPL'}}\n"
     }
    ],
    "source": [
-    "pprint(c.quote('aapl'))"
+    "pprint(td_client.search('aapl'))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[{'assetType': 'EQUITY',\n",
-      "  'cusip': '037833100',\n",
-      "  'description': 'Apple Inc. - Common Stock',\n",
-      "  'exchange': 'NASDAQ',\n",
-      "  'symbol': 'AAPL'}]\n"
-     ]
+     "name": "stdout",
+     "text": "{'AAPL': {'52WkHigh': 356.56,\n          '52WkLow': 192.58,\n          'askId': 'K',\n          'askPrice': 347.2,\n          'askSize': 100,\n          'assetMainType': 'EQUITY',\n          'assetType': 'EQUITY',\n          'bidId': 'K',\n          'bidPrice': 347.07,\n          'bidSize': 600,\n          'bidTick': ' ',\n          'closePrice': 351.73,\n          'cusip': '037833100',\n          'delayed': False,\n          'description': 'Apple Inc. - Common Stock',\n          'digits': 4,\n          'divAmount': 3.28,\n          'divDate': '2020-05-08 00:00:00.000',\n          'divYield': 0.93,\n          'exchange': 'q',\n          'exchangeName': 'NASD',\n          'highPrice': 356.56,\n          'lastId': 'D',\n          'lastPrice': 347.135,\n          'lastSize': 0,\n          'lowPrice': 345.15,\n          'marginable': True,\n          'mark': 347.2,\n          'markChangeInDouble': -4.53,\n          'markPercentChangeInDouble': -1.2879,\n          'nAV': 0.0,\n          'netChange': -4.595,\n          'netPercentChangeInDouble': -1.3064,\n          'openPrice': 354.635,\n          'peRatio': 27.5627,\n          'quoteTimeInLong': 1592611192671,\n          'regularMarketLastPrice': 349.72,\n          'regularMarketLastSize': 16,\n          'regularMarketNetChange': -2.01,\n          'regularMarketPercentChangeInDouble': -0.5715,\n          'regularMarketTradeTimeInLong': 1592596801917,\n          'securityStatus': 'Normal',\n          'shortable': True,\n          'symbol': 'AAPL',\n          'totalVolume': 66118952,\n          'tradeTimeInLong': 1592611198971,\n          'volatility': 0.0153}}\n"
     }
    ],
    "source": [
-    "pprint(c.instrument('037833100'))"
+    "pprint(td_client.quote('aapl'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "[{'assetType': 'EQUITY',\n  'cusip': '037833100',\n  'description': 'Apple Inc. - Common Stock',\n  'exchange': 'NASDAQ',\n  'symbol': 'AAPL'}]\n"
+    }
+   ],
+   "source": [
+    "pprint(td_client.instrument('037833100'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": "    close       datetime    high     low    open  volume\n0  323.80  1591354800000  323.95  323.61  323.61    2395\n1  323.75  1591354860000  323.81  323.75  323.80    1338\n2  323.78  1591354920000  323.80  323.76  323.80     423\n3  323.65  1591355040000  323.70  323.65  323.70     210\n4  323.77  1591355160000  323.77  323.68  323.70    1159",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>close</th>\n      <th>datetime</th>\n      <th>high</th>\n      <th>low</th>\n      <th>open</th>\n      <th>volume</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>323.80</td>\n      <td>1591354800000</td>\n      <td>323.95</td>\n      <td>323.61</td>\n      <td>323.61</td>\n      <td>2395</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>323.75</td>\n      <td>1591354860000</td>\n      <td>323.81</td>\n      <td>323.75</td>\n      <td>323.80</td>\n      <td>1338</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>323.78</td>\n      <td>1591354920000</td>\n      <td>323.80</td>\n      <td>323.76</td>\n      <td>323.80</td>\n      <td>423</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>323.65</td>\n      <td>1591355040000</td>\n      <td>323.70</td>\n      <td>323.65</td>\n      <td>323.70</td>\n      <td>210</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>323.77</td>\n      <td>1591355160000</td>\n      <td>323.77</td>\n      <td>323.68</td>\n      <td>323.70</td>\n      <td>1159</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "execution_count": 9
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "pd.DataFrame(td_client.history('AAPL')['candles']).head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Getting Option Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "options = td_client.options('AAPL')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Expiry Date: 2020-06-19:0\nStrike Price: 75.0\n[{'ask': 0.01,\n  'askSize': 865,\n  'bid': 0.0,\n  'bidAskSize': '0X865',\n  'bidSize': 0,\n  'closePrice': 0.0,\n  'daysToExpiration': 0,\n  'deliverableNote': '',\n  'delta': 0.0,\n  'description': 'AAPL Jun 19 2020 75.0 Put',\n  'exchangeName': 'OPR',\n  'expirationDate': 1592596800000,\n  'expirationType': 'R',\n  'gamma': 0.0,\n  'highPrice': 0.0,\n  'inTheMoney': False,\n  'isIndexOption': None,\n  'last': 0.01,\n  'lastSize': 0,\n  'lastTradingDay': 1592611200000,\n  'lowPrice': 0.0,\n  'mark': 0.01,\n  'markChange': 0.0,\n  'markPercentChange': 4900.0,\n  'mini': False,\n  'multiplier': 100.0,\n  'netChange': 0.01,\n  'nonStandard': False,\n  'openInterest': 7941,\n  'openPrice': 0.0,\n  'optionDeliverablesList': None,\n  'percentChange': 9900.0,\n  'putCall': 'PUT',\n  'quoteTimeInLong': 1592574187630,\n  'rho': 0.0,\n  'settlementType': ' ',\n  'strikePrice': 75.0,\n  'symbol': 'AAPL_061920P75',\n  'theoreticalOptionValue': 0.005,\n  'theoreticalVolatility': 29.0,\n  'theta': -0.007,\n  'timeValue': 0.01,\n  'totalVolume': 0,\n  'tradeDate': None,\n  'tradeTimeInLong': 1592243673899,\n  'vega': 0.0,\n  'volatility': 379.582}]\n"
+    }
+   ],
+   "source": [
+    "expiry_dates = list(options['putExpDateMap'].keys())\n",
+    "expiry = expiry_dates[0]\n",
+    "print(f\"Expiry Date: {expiry}\")\n",
+    "\n",
+    "strike_prices = list(options['putExpDateMap'][expiry].keys())\n",
+    "strike = strike_prices[0]\n",
+    "print(f\"Strike Price: {strike}\")\n",
+    "\n",
+    "pprint(options['putExpDateMap'][expiry][strike])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Placing an Order"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating order body for Place Order API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tdameritrade.orders.order_builder import build_buy_market_stock_order\n",
+    "\n",
+    "# Prints function docstring\n",
+    "# build_buy_market_stock_order?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "symbol = \"HUSA\"  # Cheap stock for example\n",
+    "quantity = 1\n",
+    "order = build_buy_market_stock_order(symbol, quantity)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "{'duration': 'DAY',\n 'orderLegCollection': [{'instruction': 'BUY',\n                         'instrument': {'assetType': 'EQUITY',\n                                        'symbol': 'HUSA'},\n                         'quantity': 1}],\n 'orderStrategyType': 'SINGLE',\n 'orderType': 'MARKET',\n 'session': 'NORMAL'}\n"
+    }
+   ],
+   "source": [
+    "pprint(order.asdict())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Submitting Order"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>close</th>\n",
-       "      <th>datetime</th>\n",
-       "      <th>high</th>\n",
-       "      <th>low</th>\n",
-       "      <th>open</th>\n",
-       "      <th>volume</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>222.75</td>\n",
-       "      <td>1537182000000</td>\n",
-       "      <td>222.88</td>\n",
-       "      <td>222.55</td>\n",
-       "      <td>222.78</td>\n",
-       "      <td>2920</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>222.59</td>\n",
-       "      <td>1537182060000</td>\n",
-       "      <td>222.59</td>\n",
-       "      <td>222.59</td>\n",
-       "      <td>222.59</td>\n",
-       "      <td>500</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>222.60</td>\n",
-       "      <td>1537182120000</td>\n",
-       "      <td>222.61</td>\n",
-       "      <td>222.60</td>\n",
-       "      <td>222.60</td>\n",
-       "      <td>1180</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>222.50</td>\n",
-       "      <td>1537182180000</td>\n",
-       "      <td>222.56</td>\n",
-       "      <td>222.50</td>\n",
-       "      <td>222.56</td>\n",
-       "      <td>2850</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>222.75</td>\n",
-       "      <td>1537182240000</td>\n",
-       "      <td>222.75</td>\n",
-       "      <td>222.53</td>\n",
-       "      <td>222.53</td>\n",
-       "      <td>1703</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    close       datetime    high     low    open  volume\n",
-       "0  222.75  1537182000000  222.88  222.55  222.78    2920\n",
-       "1  222.59  1537182060000  222.59  222.59  222.59     500\n",
-       "2  222.60  1537182120000  222.61  222.60  222.60    1180\n",
-       "3  222.50  1537182180000  222.56  222.50  222.56    2850\n",
-       "4  222.75  1537182240000  222.75  222.53  222.53    1703"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "pd.DataFrame(c.history('AAPL')['candles']).head()"
+    "# Without this, it fails with a 415.\n",
+    "# This may screw up other API calls, so it may have to be reset if you want to try other ones.\n",
+    "td_client.session.headers = {\n",
+    "    \"Content-Type\": \"application/json\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This will fail to return because the place order API does not return a JSONserializable response on success\n",
+    "# BUT the order will still go through.  Checked on the site.  You can also check your active orders below.\n",
+    "\n",
+    "# try:\n",
+    "#     response = td_client.placeOrder(account_id, order.json())\n",
+    "#     pprint(response)\n",
+    "# except json.decoder.JSONDecodeError as err:\n",
+    "#     print(err)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Getting out Orders"
    ]
   },
   {
@@ -229,77 +286,51 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os = c.options('AAPL')"
+    "# Load account info to get account ID for get orders\n",
+    "td_client.accounts()\n",
+    "\n",
+    "account_id = td_client.accountIds[0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "execution_count": 18,
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "[{'ask': 0.01,\n",
-      "  'askSize': 625,\n",
-      "  'bid': 0.0,\n",
-      "  'bidSize': 0,\n",
-      "  'closePrice': 0.0,\n",
-      "  'daysToExpiration': 5,\n",
-      "  'deliverableNote': '',\n",
-      "  'delta': 0.0,\n",
-      "  'description': 'AAPL Oct 5 2018 170 Put (Weekly)',\n",
-      "  'exchangeName': 'OPR',\n",
-      "  'expirationDate': 1538744400000,\n",
-      "  'expirationType': 'S',\n",
-      "  'gamma': 0.0,\n",
-      "  'highPrice': 0.0,\n",
-      "  'inTheMoney': False,\n",
-      "  'isIndexOption': None,\n",
-      "  'last': 0.01,\n",
-      "  'lastSize': 0,\n",
-      "  'lastTradingDay': 1538712000000,\n",
-      "  'lowPrice': 0.0,\n",
-      "  'mark': 0.01,\n",
-      "  'markChange': 0.0,\n",
-      "  'markPercentChange': 4900.0,\n",
-      "  'mini': False,\n",
-      "  'multiplier': 100.0,\n",
-      "  'netChange': 0.01,\n",
-      "  'nonStandard': False,\n",
-      "  'openInterest': 590,\n",
-      "  'openPrice': 0.0,\n",
-      "  'optionDeliverablesList': None,\n",
-      "  'percentChange': 9900.0,\n",
-      "  'putCall': 'PUT',\n",
-      "  'quoteTimeInLong': 1538164799058,\n",
-      "  'rho': 0.0,\n",
-      "  'settlementType': ' ',\n",
-      "  'strikePrice': 170.0,\n",
-      "  'symbol': 'AAPL_100518P170',\n",
-      "  'theoreticalOptionValue': 0.0,\n",
-      "  'theoreticalVolatility': 29.0,\n",
-      "  'theta': -0.0,\n",
-      "  'timeValue': 0.01,\n",
-      "  'totalVolume': 0,\n",
-      "  'tradeDate': None,\n",
-      "  'tradeTimeInLong': 1538076048243,\n",
-      "  'vega': 0.0,\n",
-      "  'volatility': 0.0}]\n"
-     ]
+     "name": "stdout",
+     "text": "[]\n"
     }
    ],
    "source": [
-    "pprint(os['putExpDateMap']['2018-10-05:5']['170.0'])"
+    "# Print out orders\n",
+    "my_orders = td_client.orders(accountId=account_id)\n",
+    "pprint(my_orders)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Deleting Orders"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# This deletes all WORKING orders\n",
+    "\n",
+    "# for order in my_orders:\n",
+    "#     if order[\"status\"] == Status.WORKING and order[\"cancelable\"]:\n",
+    "#         response = td_client.cancelOrder(account_id, order[\"orderId\"])\n",
+    "#         pprint(response)"
+   ]
   }
  ],
  "metadata": {
@@ -318,7 +349,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.7.3-final"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Cleaned up the notebook a bit and added an example of the orders submodule from PR #98 

View Notebook Online:
https://mybinder.org/v2/gh/ChocoShell/tdameritrade/2ae722bf436273a235f5415210402283a775faa4