### PR TITLE
Forward API errors down the library user

### DIFF
--- a/tdameritrade/exceptions.py
+++ b/tdameritrade/exceptions.py
@@ -1,3 +1,4 @@
+import json
 
 def handle_error_response(resp):
     codes = {
@@ -9,7 +10,13 @@ def handle_error_response(resp):
         -1: TDAAPIError
     }
 
-    raise codes[resp.status_code]()
+    try:
+        body = resp.content.decode('utf-8')
+        data = json.loads(body)
+        message = data.get('error', body)
+    except:
+        raise codes[resp.status_code]()
+    raise codes[resp.status_code](message=message, code=resp.status_code, data=data, response=resp)
 
 
 class TDAAPIError(Exception):


### PR DESCRIPTION
If you set a buy or sell limit too high or too low you'll receive:

`{'error': 'Limit price too agressive'}`

However, to the end user of the library you only get a ValidationError.  This pull requests attempts to pass the error down the chain. 