### PR TITLE
authentication element fix

### DIFF
--- a/tdameritrade/auth/__init__.py
+++ b/tdameritrade/auth/__init__.py
@@ -64,8 +64,8 @@ def authentication(client_id, redirect_uri, tdauser=None, tdapass=None):
     # Fully automated oauth2 authentication (if tdauser and tdapass were inputed into the function, or found as
     # environment variables)
     if tdauser and tdapass:
-        ubox = driver.find_element(By.ID, "username")
-        pbox = driver.find_element(By.ID, "password")
+        ubox = driver.find_element(By.ID, "username0")
+        pbox = driver.find_element(By.ID, "password1")
         ubox.send_keys(tdauser)
         pbox.send_keys(tdapass)
         driver.find_element(By.ID, "accept").click()


### PR DESCRIPTION
Automatic authentication was failing because the TDA authentication page element ID names have changed. This small change updates the authentication IDs in the code to correct for the current ID names.